### PR TITLE
Use CTest module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ add_definitions(-std=c99)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall")
 
-enable_testing()
+include( CTest )
 
 add_subdirectory(src)
 add_subdirectory(tests)


### PR DESCRIPTION
This helps in building with test disabled if one
needs to do that. e.g. cross-compiling

cmake BUILD_TESTING=OFF

would disable the CTest module otherwise the behabiour
remains same.

Signed-off-by: Khem Raj raj.khem@gmail.com
