### PR TITLE
Use BUILD_TESTING macro to add tests to build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,9 @@ add_definitions(-std=c99)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall")
 
-include( CTest )
+include(CTest)
 
 add_subdirectory(src)
-add_subdirectory(tests)
-
+if (BUILD_TESTING)
+  add_subdirectory(tests)
+endif (BUILD_TESTING)


### PR DESCRIPTION
This is to ensure that we do not build tests
when -DBUILD_TESTING=OFF is passed from cmdline

Signed-off-by: Khem Raj raj.khem@gmail.com
