### PR TITLE
Adding APIs for base64url buffer sizes

### DIFF
--- a/src/b64-decode.c
+++ b/src/b64-decode.c
@@ -204,6 +204,29 @@ static void decodeblock( const uint8_t *in, uint8_t *out )
     out[ 2 ] = (uint8_t ) (((in[2] << 6) & 0xc0) | in[3]);
 }
 
+/**
+ * Get the size of the buffer needed to hold the output decoded from
+ * base64url encoded data.
+ */
+size_t b64url_get_decoded_buffer_size( const size_t encoded_size )
+{
+	size_t decoded_size;
+    if(    (0 == encoded_size)
+        || (0 == encoded_size >> 2) ) {
+        return 0;
+    }
+
+    decoded_size = (encoded_size >> 2) * 3;
+	if( (encoded_size & 0x3)==2 ) decoded_size++;
+	if( (encoded_size & 0x3)==3 ) decoded_size+=2;
+	
+    return decoded_size;
+}
+
+/**
+ * Get the size of the buffer needed to hold the output decoded from
+ * base64 encoded data.
+ */
 size_t b64_get_decoded_buffer_size( const size_t encoded_size )
 {
     size_t decoded_size;

--- a/src/b64-decode.c
+++ b/src/b64-decode.c
@@ -211,11 +211,7 @@ static void decodeblock( const uint8_t *in, uint8_t *out )
 size_t b64url_get_decoded_buffer_size( const size_t encoded_size )
 {
 	size_t decoded_size;
-    if(    (0 == encoded_size)
-        || (0 == encoded_size >> 2) ) {
-        return 0;
-    }
-
+    
     decoded_size = (encoded_size >> 2) * 3;
 	if( (encoded_size & 0x3)==2 ) decoded_size++;
 	if( (encoded_size & 0x3)==3 ) decoded_size+=2;

--- a/src/b64.c
+++ b/src/b64.c
@@ -207,6 +207,19 @@ VERSION HISTORY:
 **char cb64[]="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 */
 
+
+/**
+ *  Get the size of the buffer required to hold the decoded data when base64 url encoded.
+ *  Not supported
+ */
+size_t b64url_get_encoded_buffer_size( const size_t decoded_size )
+{
+	return decoded_size;
+}
+
+/**
+ *  Get the size of the buffer required to hold the decoded data when base64 encoded.
+ */
 size_t b64_get_encoded_buffer_size( const size_t decoded_size )
 {
     return ((decoded_size + 2) / 3) << 2;

--- a/src/base64.h
+++ b/src/base64.h
@@ -33,6 +33,18 @@ extern "C" {
  */
 size_t b64_get_encoded_buffer_size( const size_t decoded_size );
 
+/**
+ *
+ *  Get the size of the buffer required to hold the decoded data when base64 url encoded.
+ *
+ *  @note : Not supported 
+ *
+ *  @param decoded_size size of the decoded date
+ *
+ *  @return size of the buffer required to hold the encoded data
+ */
+size_t b64url_get_encoded_buffer_size( const size_t decoded_size );
+
 
 /**
  *  Encodes the input into base 64.  The base 64 produced string will be placed
@@ -60,6 +72,17 @@ void b64_encode( const uint8_t *input, const size_t input_size, uint8_t *output 
  */
 size_t b64_get_decoded_buffer_size( const size_t encoded_size );
 
+/**
+ * Get the size of the buffer needed to hold the output decoded from
+ * base64url encoded data.
+ *
+ * @note: The size MAY be larger the the resulting decoded output.
+ *
+ * @param encoded_size size of the base64url encoded data
+ *
+ * @return size of the raw data
+ */
+size_t b64url_get_decoded_buffer_size( const size_t encoded_size );
 
 /**
  * Decodes the base 64 stream.  The produced raw buffer will be placed into the

--- a/tests/simple.c
+++ b/tests/simple.c
@@ -35,6 +35,10 @@ void test_encoded_size() {
     CU_ASSERT_EQUAL(b64_get_encoded_buffer_size(300), 400);
 }
 
+void test_b64url_encoded_size() {
+    CU_ASSERT_EQUAL(b64url_get_encoded_buffer_size(0), 0);
+}
+
 void test_decoded_size() {
     CU_ASSERT_EQUAL(b64_get_decoded_buffer_size(0), 0);
     CU_ASSERT_EQUAL(b64_get_decoded_buffer_size(1), 0);
@@ -47,8 +51,8 @@ void test_decoded_size() {
 void test_b64url_decoded_size() {
     CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(0), 0);
     CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(1), 0);
-    CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(2), 0);
-    CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(3), 0);
+    CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(2), 1);
+    CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(3), 2);
     CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(4), 3);
     CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(8), 6);
 	CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(51), 38);

--- a/tests/simple.c
+++ b/tests/simple.c
@@ -44,6 +44,21 @@ void test_decoded_size() {
     CU_ASSERT_EQUAL(b64_get_decoded_buffer_size(8), 6);
 }
 
+void test_b64url_decoded_size() {
+    CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(0), 0);
+    CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(1), 0);
+    CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(2), 0);
+    CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(3), 0);
+    CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(4), 3);
+    CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(8), 6);
+	CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(51), 38);
+	CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(52), 39);
+	CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(53), 39);
+	CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(54), 40);
+	CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(55), 41);
+	CU_ASSERT_EQUAL(b64url_get_decoded_buffer_size(56), 42);
+}
+
 void test_encode() {
     CU_ASSERT_FALSE(test_encoded_stuff( (uint8_t*)"leasure.", 8, (uint8_t*)"bGVhc3VyZS4=", 12 ));
     CU_ASSERT_FALSE(test_encoded_stuff( (uint8_t*)"easure.", 7, (uint8_t*)"ZWFzdXJlLg==", 12 ));
@@ -128,6 +143,7 @@ void add_suites( CU_pSuite *suite )
     *suite = CU_add_suite( "Base64 encoding tests", NULL, NULL );
     CU_add_test( *suite, "Get the Encoded Size     ", test_encoded_size );
     CU_add_test( *suite, "Get the Decoded Size     ", test_decoded_size );
+	CU_add_test( *suite, "Get the base64url Decoded Size", test_b64url_decoded_size );
     CU_add_test( *suite, "Get the Encode           ", test_encode );
     CU_add_test( *suite, "Get the Decode           ", test_decode );
     CU_add_test( *suite, "Get the URL Decode       ", test_url_decode );


### PR DESCRIPTION
Added new APIs -
b64url_get_encoded_buffer_size
b64url_get_decoded_buffer_size


